### PR TITLE
Resolve #6 by adding settings via presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ the following combinations will be applied on your selected photos: <br>
 > * Clarity
 > * Vibrance
 > * Saturation
+> * Texture
+> * Dehaze
 
 ## 🛠Getting Started
 

--- a/lightroom_plugin.lrdevplugin/LibraryMenuItemPluginUI.lua
+++ b/lightroom_plugin.lrdevplugin/LibraryMenuItemPluginUI.lua
@@ -104,7 +104,7 @@ function editPhotos(photos, keyTable, settingsTable)
                     if requiresPreset(keyTable[key]) then
                         adjustImageUsingPreset(picture, keyTable[key], 0)
                     else
-                        picture:quickDevelopAdjustImage(keyTable[key], 0) -- reset values for further editing
+                        picture:quickDevelopAdjustImage(keyTable[key], 0)
                     end
                 end
             end
@@ -133,6 +133,11 @@ function editSinglePhoto(keyTable, photos, data)
             if requiresPreset(keyTable[key]) then
                 adjustImageUsingPreset(photo, keyTable[key], tonumber(value))
             else
+                photo:quickDevelopAdjustImage(keyTable[key], 0)
+                -- photo:quickDevelopAdjustImage( settingName, size ) seems to act pretty weird:
+                -- if size is a number different from 0, the setting is set to <value before> + size
+                -- however, if size is 0, the setting is set to 0
+                -- the line above ensures that the setting is 0 before the next line
                 photo:quickDevelopAdjustImage(keyTable[key], tonumber(value))
             end
             progressBar:setPortionComplete(count, times * #targetPhotosCopies)

--- a/lightroom_plugin.lrdevplugin/LibraryMenuItemPluginUI.lua
+++ b/lightroom_plugin.lrdevplugin/LibraryMenuItemPluginUI.lua
@@ -149,7 +149,8 @@ end
 function adjustImageUsingPreset(photo, setting, value)
     LrTasks.startAsyncTask (function ()
 	catalog:withWriteAccessDo ("Create Preset", function()
-	    local presetSettings = {setting = value}
+	    local presetSettings = {}
+            presetSettings[setting] = value
             local tmpPreset = LrApplication.addDevelopPresetForPlugin(_PLUGIN, "TmpPreset", presetSettings)
             photo:applyDevelopPreset(tmpPreset, _PLUGIN)
 	end, {timeout = 15})


### PR DESCRIPTION
Add a list of settings that are not available via quick develop, for now containing _texture_ and _dehaze_. Upon editing a photo (and resetting the values at the end), check for each setting whether it is in this list. If so, adjust it by creating and applying a develop preset.